### PR TITLE
アニメーションコピーのモーダルの表示名変更

### DIFF
--- a/js/action/common.js
+++ b/js/action/common.js
@@ -493,7 +493,7 @@ export function click_animation_name_list_copy(){
     speed : "0.3s",
     
     // [上段] タイトル表示文字列
-    title   : "Animation edit",
+    title   : "Animation copy",
     // [中断] メッセージ表示スタイル
     message : {
       html    : Options.common.get_template('animation_name_modal'),


### PR DESCRIPTION
アニメーションコピーのモーダルの表示名を、下図のようにanimation editからanimation copyに変更した（animation editだと、名前変更モーダルとかぶっているため）。

<img width="587" alt="スクリーンショット 2022-08-27 0 09 12" src="https://user-images.githubusercontent.com/31335394/186997362-8a74211f-a63a-4433-9277-0ffcba4b25f6.png">
